### PR TITLE
Pass callback URL to MediaWiki in initial handshake

### DIFF
--- a/mwoauth/__init__.py
+++ b/mwoauth/__init__.py
@@ -4,4 +4,4 @@ from .handshaker import Handshaker
 from .tokens import AccessToken, ConsumerToken, RequestToken
 from .functions import initiate, complete, identify
 
-__version__ = "0.2.5"  # Change in setup.py too
+__version__ = "0.2.6"  # Change in setup.py too

--- a/mwoauth/functions.py
+++ b/mwoauth/functions.py
@@ -50,7 +50,7 @@ def force_unicode(val):
             return unicode(val, "unicode-escape")
 
 
-def initiate(mw_uri, consumer_token, callback=None):
+def initiate(mw_uri, consumer_token, callback='oob'):
     """
     Initiates an oauth handshake with MediaWik.
 
@@ -61,6 +61,8 @@ def initiate(mw_uri, consumer_token, callback=None):
         consumer_token : :class:`~mwoauth.ConsumerToken`
             A token representing you, the consumer.  Provided by MediaWiki via
             ``Special:OAuthConsumerRegistration``.
+        callback : `str`
+            Callback URL. Defaults to 'oob'.
 
     :Returns:
         A `tuple` of two values:
@@ -72,7 +74,7 @@ def initiate(mw_uri, consumer_token, callback=None):
     """
     auth = OAuth1(consumer_token.key,
                   client_secret=consumer_token.secret,
-                  callback_uri='oob')
+                  callback_uri=callback)
 
     r = requests.post(url=mw_uri,
                       params={'title': "Special:OAuth/initiate"},
@@ -101,9 +103,6 @@ def initiate(mw_uri, consumer_token, callback=None):
     params = {'title': "Special:OAuth/authorize",
               'oauth_token': request_token.key,
               'oauth_consumer_key': consumer_token.key}
-
-    if callback is not None:
-        params['callback'] = callback
 
     return (
         mw_uri + "?" + urlencode(params),

--- a/mwoauth/handshaker.py
+++ b/mwoauth/handshaker.py
@@ -49,9 +49,13 @@ class Handshaker(object):
         self.mw_uri = mw_uri
         self.consumer_token = consumer_token
 
-    def initiate(self, callback=None):
+    def initiate(self, callback='oob'):
         """
         Initiates an OAuth handshake with MediaWiki.
+
+        :Parameters:
+            callback : `str`
+                Callback URL. Defaults to 'oob'.
 
         :Returns:
             A `tuple` of two values:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def requirements(fname):
 
 setup(
     name="mwoauth",
-    version="0.2.5",  # Change in mwoauth/__init__.py too
+    version="0.2.6",  # Change in mwoauth/__init__.py too
     author="Aaron Halfaker / Filippo Valsorda",
     author_email="ahalfaker@wikimedia.org",
     description=("A generic MediaWiki OAuth handshake helper."),


### PR DESCRIPTION
Fix the handling of the optional callback URL introduced in a90305c. The
callback is sent as part of the backend initialization call rather than as
a parameter in the authorization request carried by the consumer.