### PR TITLE
Fix tox after introduction of mwoauth.flask

### DIFF
--- a/doc/flask.rst
+++ b/doc/flask.rst
@@ -1,4 +1,0 @@
-mwoauth.flask
-=============
-
-.. automodule:: mwoauth.flask

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,6 +61,12 @@ Stateless functions
 .. autofunction:: mwoauth.identify
 
 
+Flask Blueprint
+===============
+
+.. automodule:: mwoauth.flask
+
+
 About
 =================
 :authors:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import find_packages, setup
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 about_path = os.path.join(os.path.dirname(__file__), "mwoauth/about.py")
 exec(compile(open(about_path).read(), about_path, "exec"))
 
@@ -27,6 +28,9 @@ setup(
         'requests-oauthlib',
         'six'
     ],
+    extras_require={
+        'flask': ['flask'],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Security",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
+       flask
 commands=python setup.py test
 
 [testenv:py27]
@@ -15,8 +16,9 @@ basepython = python3.5
 
 [testenv:doc]
 deps = -r{toxinidir}/requirements.txt
+       flask
        sphinx
-commands = sphinx-build -W -b html doc/ doc/_build/html
+commands = sphinx-build -b html doc/ doc/_build/html
 
 [testenv:flake8]
 commands = flake8 {posargs}


### PR DESCRIPTION
Fix several small issues with running `tox`:
* Add `extras_require` section to setup.py for optional flask
  dependency.
* Add flask to tox virtual environment dependencies.
* Stop treating sphinx warnings as errors because of sphinx bug where
  `**kwargs` in method signature causes warning about "Inline strong
  start-string without end-string".
* Move Flask Blueprint docs into main documentation. Sphinx was raising
  a warning because the separate file was not included in navigation.
  Having the doc in the main page makes it a bit more discoverable.
* Fully qualify references to flask components in `mwoauth.flask`.
  Sphinx was confused about the imports.
* Fix flake8 warnings by always putting `**kwargs` useage at end of
  argument lists.
* Fix flake8 warning in setup.py for 1 blank line after method
  declaration.
* Fix unordered list in `mwoauth.flask.MWOAuth` docstring.