### PR TITLE
Check for errors in identify()

### DIFF
--- a/mwoauth/functions.py
+++ b/mwoauth/functions.py
@@ -242,6 +242,19 @@ def identify(mw_uri, consumer_token, access_token, leeway=10.0,
                       auth=auth,
                       headers={'User-Agent': user_agent})
 
+    # Special:OAuth/identify unhelpfully returns 200 status even when there is
+    # an error in the API call. Check for error messages manually.
+    try:
+        resp = r.json()
+        if 'error' in resp:
+            raise OAuthException(
+                "A MediaWiki API error occurred: {0}".format(resp['message']))
+    except ValueError as e:
+        raise OAuthException(
+            "An error occurred while trying to read json " +
+            "content: {0}".format(e))
+
+
     # Decode json & stuff
     try:
         identity = jwt.decode(r.content, consumer_token.secret,


### PR DESCRIPTION
The Special:OAuth/identify endpoint returns a '200 OK' HTTP status code
even if the API request itself failed for some reason. The JSON response
payload can be checked by looking for an 'error' member in the response
body. This can be very help when debugging configuration issues such as
attempting to verify identity against a wiki where the consumer token is
invalid.