### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyJWT == 1.7.1
+requests == 2.2.1
 requests-oauthlib == 1.2.0
 six == 1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-PyJWT == 1.0.1
-oauthlib == 0.6.1
-requests == 2.2.1
-requests-oauthlib == 0.4.0
-six == 1.5.2
+PyJWT == 1.7.1
+oauthlib == 2.1.0
+requests == 2.21.0
+requests-oauthlib == 1.1.0
+six == 1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 PyJWT == 1.7.1
-oauthlib == 2.1.0
-requests == 2.21.0
-requests-oauthlib == 1.1.0
+requests-oauthlib == 1.2.0
 six == 1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyJWT == 1.7.1
-requests == 2.2.1
+requests == 2.21.0
 requests-oauthlib == 1.2.0
 six == 1.12.0


### PR DESCRIPTION
There have been numerous security updates and bugfixes to the dependencies listed in requirements.txt. Updating these does not seem to have any negative impact on the [Wikipedia Library Card Platform](https://github.com/WikipediaLibrary/TWLight), which is currently on python2.