### PR TITLE
unpin pyjwt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     long_description=read('README.rst'),
     install_requires=[
-        'PyJWT>=1.0.1,<2.0.0',
+        'PyJWT>=1.0.1',
         'oauthlib',
         'requests',
         'requests-oauthlib',


### PR DESCRIPTION
pinning down pyjwt appears to be unnecessary, as the current use of pyjwt works just fine with pyjwt 2.